### PR TITLE
FIX Add continuous integration on Windows 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ PySofia
 
 .. image:: https://travis-ci.org/rth/pysofia.svg?branch=master
     :target: https://travis-ci.org/rth/pysofia
+.. image:: https://ci.appveyor.com/api/projects/status/jhn2d8n8y836pnj8/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/rth/pysofia/branch/master
 
 PySofia is a python wrapper around the methods present in the C++ sofia-ml library. These include Stochastic Gradient Descent implementations of some ranking algorithms, notably RankSVM.
 

--- a/README.rst
+++ b/README.rst
@@ -1,26 +1,27 @@
+PySofia
+=======
+
 .. image:: https://travis-ci.org/rth/pysofia.svg?branch=master
     :target: https://travis-ci.org/rth/pysofia
-
-
-PySofia
-=============================
 
 PySofia is a python wrapper around the methods present in the C++ sofia-ml library. These include Stochastic Gradient Descent implementations of some ranking algorithms, notably RankSVM.
 
 Dependencies
 ------------
 
-  - cython >= 0.17 (previous versions will not work)
-  - numpy
-  - sklearn >= 0.15
-  - six
-  - enum34 (for Python versions before 3.4)
-  - A C++ compiler (gcc will do)
+- cython >= 0.17 (previous versions will not work)
+- numpy
+- sklearn >= 0.15
+- six
+- enum34 (for Python versions before 3.4)
+- A C++ compiler (gcc will do)
 
 You will not need to install sofia-ml since it is incuded in this distribution
 
 Installation
 ============
+
+::
 
     $ pip install -U git+https://github.com/rth/pysofia.git
 
@@ -49,4 +50,4 @@ Apache License 2.0
 Authors
 =======
 
-PySofia is the work of Fabian Pedregosa. The sofia-ml library is written by D. Sculley.
+PySofia is the work of Fabian Pedregosa, currently maintained by R. Yurchak. The sofia-ml library is written by D. Sculley.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   # create a conda virtual environement 
   - "conda create -n sofia-env numpy=1.10 scipy cython nose six scikit-learn=0.17 python=%PYTHON_VERSION%"
   - activate sofia-env
-  - python setup.py install
+  - python setup.py develop
 
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+# Adapted from https://github.com/bsmurphy/PyKrige/blob/master/appveyor.yml
+build: false
+
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
+  matrix:
+    - PYTHON_VERSION: 3.5
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
+    # not running the tests on 32 bit Python at the moment
+    # as AppVeyor is just too slow
+    #- PYTHON_VERSION: 2.7
+    #  PYTHON_ARCH: "64"
+    #  MINICONDA: C:\Miniconda-x64
+    #- PYTHON_VERSION: 2.7
+    #  PYTHON_ARCH: "32"
+    #  MINICONDA: C:\Miniconda
+    #- PYTHON_VERSION: 3.5
+    #  PYTHON_ARCH: "32"
+    #  MINICONDA: C:\Miniconda3
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
+
+install:
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  # create a conda virtual environement 
+  - "conda create -n sofia-env numpy=1.10 scipy cython nose six scikit-learn=0.17 python=%PYTHON_VERSION%"
+  - activate sofia-env
+  - python setup.py install
+
+
+
+test_script:
+  - "cd C:\\projects"
+  - activate sofia-env # activate the virtualenv
+  - nosetests -svv pysofia/pysofia/tests/

--- a/pysofia/sofia_ml.py
+++ b/pysofia/sofia_ml.py
@@ -8,7 +8,6 @@ import sys, tempfile
 import six
 import numpy as np
 from sklearn import datasets
-from . import _sofia_ml
 
 
 from enum import Enum
@@ -78,6 +77,7 @@ def svm_train(X, y, b, alpha, n_samples, n_features, learner, loop, eta,
     coef
 
     """
+    from pysofia import _sofia_ml
     if isinstance(X, six.string_types):
         if n_features is None:
             n_features = 2**17 # the default in sofia-ml TODO: parse file to see
@@ -104,6 +104,7 @@ def svm_train(X, y, b, alpha, n_samples, n_features, learner, loop, eta,
 
 def svm_predict(data, coef, predict_type=predict_type.linear, blocks=None):
     # TODO: isn't query_id in data ???
+    from pysofia import _sofia_ml
     s_coef = ' '.join(['%.5f' % e for e in coef[:-1]])
 
     if six.PY3:
@@ -146,6 +147,7 @@ def svm_update(X, y, coef, alpha, n_samples, n_features, learner, loop, eta,
     coef
 
     """
+    from pysofia import _sofia_ml
     if isinstance(X, np.ndarray):
         if n_features is None:
             n_features = X.shape[1]


### PR DESCRIPTION
Veryfing the test suite when building on Windows (issue #2 ), for the moment only for Py 3.5, 64bit. Also a few minor changes to the readme.
